### PR TITLE
Force parameters refresh when pressing the logo

### DIFF
--- a/webapp/app/index/route.js
+++ b/webapp/app/index/route.js
@@ -3,6 +3,6 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 
 export default BaseRoute.extend(AuthenticatedRouteMixin, {
   beforeModel: function() {
-    this.transitionTo('sessions');
+    this.transitionTo('sessions',{queryParams: {page: 1, filter: undefined, show_archived:false}});
   }
 });


### PR DESCRIPTION
resetController isn't enough to ensure pressing the logo goes to homepage, because we might not be exiting the session controller. It's best to force the parameters back to defaults in this special use case.