### PR TITLE
Feature/extend backslash api

### DIFF
--- a/flask_app/blueprints/rest.py
+++ b/flask_app/blueprints/rest.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member
 import math
 import os
+import json
 
 import requests
 
@@ -59,9 +60,17 @@ class SessionMetadataResource(ModelResource):
             returned = returned.filter(SessionMetadata.key == args.key)
 
         # filter by value
-        # TODO: Allow generic parsing of jsonb column data
+        # TODO: Allow generic parsing of jsonb column data (need to add "" around string )
         if args.value is not None:
-            returned = returned.filter(SessionMetadata.metadata_item == args.value)
+            
+            # convert strings to json string (add "")
+            value = json.dumps(args.value)
+
+            # if value is an integer do not cast
+            if args.value.isnumeric():
+                value = args.value
+
+            returned = returned.filter(SessionMetadata.metadata_item == value)
 
         return returned
 

--- a/flask_app/models.py
+++ b/flask_app/models.py
@@ -497,7 +497,7 @@ class Test(db.Model, TypenameMixin, StatusPredicatesMixin, HasSubjectsMixin, Use
 _METADATA_KEY_TYPE = db.String(1024)
 
 
-class TestMetadata(db.Model):
+class TestMetadata(db.Model, TypenameMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     test_id = db.Column(
@@ -506,7 +506,7 @@ class TestMetadata(db.Model):
     metadata_item = db.Column(JSONB)
 
 
-class SessionMetadata(db.Model):
+class SessionMetadata(db.Model, TypenameMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     session_id = db.Column(


### PR DESCRIPTION
In order to auto-generate a report mapping requirements to integration tests, we needed to add some additional endpoints to the backslash server allowing for querying of test and session metadata.